### PR TITLE
Fix profile settings keyboard scroll

### DIFF
--- a/src/screens/UserScreens/ProfileScreens/ProfileSettingsScreen.tsx
+++ b/src/screens/UserScreens/ProfileScreens/ProfileSettingsScreen.tsx
@@ -70,7 +70,8 @@ const ProfileSettingsScreen = () => {
 
       {/* —— form ——*/}
       <KeyboardAwareScrollView
-        contentContainerStyle={{ padding: 24, flex: 1 }}
+        style={{ flex: 1 }}
+        contentContainerStyle={{ padding: 24, flexGrow: 1 }}
         keyboardShouldPersistTaps="handled"
         enableAutomaticScroll
         enableOnAndroid


### PR DESCRIPTION
## Summary
- ensure the profile settings screen scrolls when the keyboard appears by using `flexGrow` in the keyboard aware container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f4283d0508321ad555d55f20a1d8c