### PR TITLE
Improve NSFW URL filtering

### DIFF
--- a/src/screens/UserScreens/PostScreens/PostScreen.tsx
+++ b/src/screens/UserScreens/PostScreens/PostScreen.tsx
@@ -9,35 +9,7 @@ import { NewPostInput } from '../../../redux/types';
 import { postToFeed } from '../../../redux/slices/feedSlice';
 import { useAppDispatch, useAppSelector } from '../../../redux/store';
 import { BottomNavScreen } from '../../../components/BottomNav';
-
-const normalizeUrl = (url: string): string => {
-  if (!/^https?:\/\//i.test(url)) {
-    return `https://${url}`;
-  }
-  return url;
-};
-
-const unsafeDomains = ['porn', 'xvideos', 'redtube', 'onlyfans', 'nsfw', 'lush'];
-/**
- * Checks if a given URL points to a known NSFW domain.
- *
- * @param normalizedURL - The URL string to validate
- * @returns true if safe, false if blocked
- */
-const isSafeURL = (normalizedURL: string): boolean => {
-  try {
-    const parsed = new URL(normalizedURL);
-    const hostname = parsed.hostname.toLowerCase();
-
-    return !unsafeDomains.some(blocked => {
-      return (
-        hostname === blocked || hostname === `www.${blocked}` || hostname.endsWith(`.${blocked}`)
-      );
-    });
-  } catch {
-    return false; // invalid URL
-  }
-};
+import { normalizeUrl, isSafeURL } from '../../../utils/url';
 
 type PostScreenProps = {
   setFocusedScreen: (screen: BottomNavScreen) => void;

--- a/src/screens/UserScreens/PostScreens/__tests__/isSafeURL.test.ts
+++ b/src/screens/UserScreens/PostScreens/__tests__/isSafeURL.test.ts
@@ -1,0 +1,14 @@
+import { isSafeURL } from '../../../../utils/url';
+
+describe('isSafeURL', () => {
+  test('blocks known NSFW domains', () => {
+    expect(isSafeURL('https://xvideos.com')).toBe(false);
+    expect(isSafeURL('http://www.onlyfans.com')).toBe(false);
+    expect(isSafeURL('https://foo.redtube')).toBe(false);
+  });
+
+  test('allows safe domains', () => {
+    expect(isSafeURL('https://example.com')).toBe(true);
+    expect(isSafeURL('https://subdomain.example.com')).toBe(true);
+  });
+});

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,26 @@
+export const normalizeUrl = (url: string): string => {
+  if (!/^https?:\/\//i.test(url)) {
+    return `https://${url}`;
+  }
+  return url;
+};
+
+const unsafeDomains = ['porn', 'xvideos', 'redtube', 'onlyfans', 'nsfw', 'lush'];
+
+/**
+ * Checks if a given URL points to a known NSFW domain.
+ *
+ * @param normalizedURL - The URL string to validate
+ * @returns true if safe, false if blocked
+ */
+export const isSafeURL = (normalizedURL: string): boolean => {
+  try {
+    const hostname = new URL(normalizedURL).hostname.toLowerCase();
+    return !unsafeDomains.some(blocked => {
+      const pattern = new RegExp(`(^|\\.)${blocked}($|\\.)`);
+      return pattern.test(hostname);
+    });
+  } catch {
+    return false; // invalid URL
+  }
+};


### PR DESCRIPTION
## Summary
- move `normalizeUrl` and `isSafeURL` into a new `src/utils/url.ts`
- refactor `PostScreen` to use the new helpers
- update unit tests for `isSafeURL`

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_684f409163b48321bf71b83edd628d25